### PR TITLE
Add a dark mode

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,16 +2,15 @@ name: Deploy to GH Pages
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
 
 permissions:
   contents: write
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - name: Checkout Field Guide
       uses: actions/checkout@v3
@@ -36,7 +35,7 @@ jobs:
         path: 'tfc'
     - name: Build
       run: |
-        python src/main.py --tfc-dir tfc --out-dir build --resource-pack-book --root-dir "Field-Guide" --use-mcmeta --use-addons --copy-existing-versions
+        python src/main.py --tfc-dir tfc --out-dir build --resource-pack-book --root-dir "${GITHUB_REPOSITORY#*/}" --use-mcmeta --use-addons --copy-existing-versions
         touch build/.nojekyll
     - name: Deploy
       uses: JamesIves/github-pages-deploy-action@v4

--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -3,8 +3,26 @@
     --table-bg-light-color: #f8f8f8;
 }
 
+#nav-primary {
+    background-color: var(--bs-gray-800);
+}
+
+.card-body > *:last-child {
+    margin-bottom: 0;
+}
+
 .carousel-inner img {
     margin: auto;
+}
+
+img.icon-title {
+    height: 48px;
+    image-rendering: pixelated;
+}
+
+img.entry-card-icon {
+    height: 32px;
+    image-rendering: pixelated;
 }
 
 @media only screen and (min-width: 500px) {
@@ -12,28 +30,6 @@
     .carousel-control-prev {
         filter: invert(100%);
     }
-}
-
-.tooltip {
-    position: relative;
-    display: inline-block;
-}
-
-/* For the list of links on the left side of the page */
-
-.push-right {
-    padding-left: 30px
-}
-
-/* Anchors, to account for the fixed top bar
- * https://stackoverflow.com/questions/10732690/offsetting-an-html-anchor-to-adjust-for-fixed-header
-*/
-
-a.anchor {
-    display: block;
-    position: relative;
-    top: -60px;
-    visibility: hidden;
 }
 
 /* Item Tooltips - used for patchouli:item_spotlight pages */
@@ -63,10 +59,16 @@ img.knapping-recipe {
     image-rendering: pixelated;
     width: 270px;
     height: 270px;
+    margin: 1rem 0;
 }
 
 .crafting-recipe {
     position: relative;
+    margin: 1rem 0;
+}
+
+html[data-bs-theme="dark"] .crafting-recipe > img:first-child {
+    filter: invert(100%);
 }
 
 img.recipe-item {
@@ -90,6 +92,11 @@ img.recipe-item {
     color: black;
     text-shadow: 2px 2px #D0D0D0, -1px -1px #D0D0D0;
     pointer-events: none;
+}
+
+html[data-bs-theme="dark"] .crafting-recipe-item-count {
+    color: white;
+    text-shadow: none;
 }
 
 .crafting-recipe-pos-0-0 { position: absolute; left: 20px;  top: 20px;  }
@@ -125,18 +132,17 @@ img.recipe-item {
 .minecraft-yellow   { color: #FFFF55; text-shadow: 0px 0px 4px #444; }
 .minecraft-white    { color: #FFFFFF; text-shadow: 0px 0px 4px #444; }
 
+html[data-bs-theme="dark"] .minecraft-yellow,
+html[data-bs-theme="dark"] .minecraft-white {
+    text-shadow: none;
+}
+
 /* Minecraft Font, for count/amount labels on items */
 
 @font-face {
     font-family: Minecraft;
     src: url("font.otf") format("opentype");
 }
-
-/* Font Awesome CSS */
-.fa-discord:before { content: "\f392" }
-.fa-github:before { content: "\f09b" }
-.fa-gears:before { content: "\f085" }
-
 
 /* Tables */
 figure {

--- a/assets/static/theme-switcher.js
+++ b/assets/static/theme-switcher.js
@@ -1,0 +1,77 @@
+(() => {
+  'use strict'
+
+  const getStoredTheme = () => localStorage.getItem('theme')
+  const setStoredTheme = theme => localStorage.setItem('theme', theme)
+
+  const getPreferredTheme = () => {
+    const storedTheme = getStoredTheme()
+
+    if (storedTheme) {
+      return storedTheme
+    }
+
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  }
+
+  const setTheme = theme => {
+    if (theme === 'auto') {
+      document.documentElement.setAttribute('data-bs-theme', (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'))
+    } else {
+      document.documentElement.setAttribute('data-bs-theme', theme)
+    }
+  }
+
+  setTheme(getPreferredTheme())
+
+  const showActiveTheme = (theme, focus = false) => {
+    const themeSwitcher = document.querySelector('#bd-theme')
+
+    if (!themeSwitcher) {
+      return
+    }
+
+    const themeSwitcherText = document.querySelector('#bd-theme-text')
+    const activeThemeIcon = document.querySelector('#bd-theme-icon-active')
+    const btnToActive = document.querySelector(`[data-bs-theme-value="${theme}"]`)
+    const iconToActive = btnToActive.querySelector('i')
+    const classesOfActiveBtn = Array.from(iconToActive.classList).
+      filter(className => className.startsWith('bi'))
+
+    document.querySelectorAll('[data-bs-theme-value]').forEach(element => {
+      element.classList.remove('active')
+      element.setAttribute('aria-pressed', 'false')
+    })
+
+    btnToActive.classList.add('active')
+    btnToActive.setAttribute('aria-pressed', 'true')
+    activeThemeIcon.className = classesOfActiveBtn.join(' ')
+    const themeSwitcherLabel = `${themeSwitcherText.textContent} (${btnToActive.dataset.bsThemeValue})`
+    themeSwitcher.setAttribute('aria-label', themeSwitcherLabel)
+
+    if (focus) {
+      themeSwitcher.focus()
+    }
+  }
+
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+    const storedTheme = getStoredTheme()
+    if (storedTheme !== 'light' && storedTheme !== 'dark') {
+      setTheme(getPreferredTheme())
+    }
+  })
+
+  window.addEventListener('DOMContentLoaded', () => {
+    showActiveTheme(getPreferredTheme())
+
+    document.querySelectorAll('[data-bs-theme-value]')
+      .forEach(toggle => {
+        toggle.addEventListener('click', () => {
+          const theme = toggle.getAttribute('data-bs-theme-value')
+          setStoredTheme(theme)
+          setTheme(theme)
+          showActiveTheme(theme, true)
+        })
+      })
+  })
+})()

--- a/assets/static/tooltips.js
+++ b/assets/static/tooltips.js
@@ -1,0 +1,5 @@
+window.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(tooltipToggleEl => {
+    new bootstrap.Tooltip(tooltipToggleEl)
+  })
+})

--- a/assets/templates/default.html
+++ b/assets/templates/default.html
@@ -1,80 +1,149 @@
-<!DOCTYPE html>
-<html style="width:100%; height:100%; padding:0px; margin:0px;">
-<head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
-    <meta charset="UTF-8">
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title>{title}</title>
 
-    <!-- Bootstrap -->
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
-
-    <!-- Font Awesome -->
-    <script src="{root}/static/icons.min.js" type="text/javascript"></script>
-
-    <!-- JQuery, Bootstrap JS -->
-    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
-
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <link rel="stylesheet" href="{root}/static/style.css">
+  </head>
+  <body>
+    <!-- Load theme switcher JavaScript early to avoid flashes of incorrectly-themed content -->
+    <script src="{root}/static/theme-switcher.js"></script>
 
-    <script type="text/javascript">
-        window._CURRENT_ROOT = '{root}';
-        window._CURRENT_LANG = '{current_lang_key}';
-        $(function () {{
-            $('[data-toggle="tooltip"]').tooltip();
-        }})
+    <nav id="nav-primary" class="navbar navbar-expand-lg mb-5" data-bs-theme="dark">
+      <div class="container">
+        <a class="navbar-brand fw-bold" href="{index}">{title}</a>
+
+        <!-- Navbar toggle control for small screens -->
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-content" aria-controls="navbar-content" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+
+        <div class="collapse navbar-collapse d-flex justify-content-end" id="navbar-content">
+          <ul class="navbar-nav">
+            <!-- Version submenu -->
+            <li class="nav-item px-2 dropdown" id="version-dropdown">
+              <a class="nav-link dropdown-toggle" id="version-dropdown-button" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                <i class="bi bi-collection-fill"></i> {text_version} {tfc_version}
+              </a>
+              <div class="dropdown-menu" aria-labelledby="version-dropdown-button" id="version-dropdown-menu">
+              </div>
+            </li>
+
+            <!-- Language submenu -->
+            <li class="nav-item px-2 dropdown">
+              <a class="nav-link dropdown-toggle" id="lang-dropdown-button" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                <i class="bi bi-translate"></i> {current_lang}
+              </a>
+              <div class="dropdown-menu" aria-labelledby="lang-dropdown-button">
+                {langs}
+              </div>
+            </li>
+
+            <!-- Theme switcher -->
+            <li class="nav-item ps-2 dropdown">
+              <button id="bd-theme" class="btn btn-link nav-link dropdown-toggle" type="button" aria-expanded="false" data-bs-toggle="dropdown" data-bs-display="static">
+                <i id="bd-theme-icon-active"></i>
+                <span id="bd-theme-text" class="d-lg-none ms-2">Toggle theme</span>
+              </button>
+
+              <ul class="dropdown-menu dropdown-menu-end">
+                <!-- Light theme -->
+                <li>
+                  <button class="dropdown-item d-flex align-items-center active" type="button" data-bs-theme-value="light">
+                    <i class="bi bi-sun-fill me-2"></i>
+                    Light
+                  </button>
+                </li>
+
+                <!-- Dark theme -->
+                <li>
+                  <button class="dropdown-item d-flex align-items-center" type="button" data-bs-theme-value="dark">
+                    <i class="bi bi-moon-stars-fill me-2"></i>
+                    Dark
+                  </button>
+                </li>
+
+                <!-- System theme -->
+                <li>
+                  <button class="dropdown-item d-flex align-items-center" type="button" data-bs-theme-value="auto">
+                    <i class="bi bi-circle-half me-2"></i>
+                    Auto
+                  </button>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+
+    <div class="container">
+      <div class="row">
+        <!-- Table of contents -->
+        <nav class="col-md-3">
+          <p class="mb-3"><strong>{text_contents}</strong></p>
+
+          <ul class="list-unstyled lh-lg">
+            <li><a href="{index}">{text_index}</a></li>
+            {contents}
+          </ul>
+        </nav>
+
+        <!-- Page content -->
+        <div class="col-md-9">
+          <nav class="mb-4" aria-label="breadcrumb">
+            <ol class="breadcrumb">
+              {location}
+            </ol>
+          </nav>
+
+          {page_content}
+        </div>
+      </div>
+    </div>
+
+    <div class="container">
+      <footer class="py-3 my-5 border-top">
+        <ul class="nav justify-content-center">
+          <!-- API docs -->
+          <li class="nav-item">
+            <a class="nav-link px-3 text-body-secondary" href="https://terrafirmacraft.github.io/Documentation/">
+              <i class="bi bi-journal-code"></i> {text_api_docs}
+            </a>
+          </li>
+
+          <!-- GitHub repo -->
+          <li class="nav-item">
+            <a class="nav-link px-3 text-body-secondary" href="https://github.com/TerraFirmaCraft/Field-Guide">
+              <i class="bi bi-github"></i> {text_github}
+            </a>
+          </li>
+
+          <!-- Discord server -->
+          <li class="nav-item">
+            <a class="nav-link px-3 text-body-secondary" href="https://discord.gg/PRuAKvY">
+              <i class="bi bi-discord"></i> {text_discord}
+            </a>
+          </li>
+        </ul>
+      </footer>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+    <script src="{root}/static/icons.min.js"></script>
+
+    <script>
+      window._CURRENT_ROOT = '{root}';
+      window._CURRENT_LANG = '{current_lang_key}';
     </script>
 
-    <!-- Automatically populate the version dropdown for newer versions -->
-    <script src="{root}/static/metadata.js" type="text/javascript"></script>
-    <script src="{root}/static/versions.js" type="text/javascript"></script>
-</head>
-<body>
-
-<nav class="navbar navbar-expand-md fixed-top bg-dark">
-    <div class="navbar-header">
-        <a class="navbar-brand text-light" href="{index}">{title}</a>
-    </div>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar-content" aria-controls="navbar-content" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbar-content">
-        <ul class="navbar-nav ml-auto">
-            <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle text-light" id="lang-dropdown-button" href="" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{current_lang}</a>
-                <div class="dropdown-menu" aria-labelledby="lang-dropdown-button">
-                    {langs}
-                </div>
-            </li>
-            <li class="nav-item active"><a class="nav-link text-light" href="{index}">{text_index}</a></li>
-            <li class="nav-item"><a class="nav-link text-light" href="https://terrafirmacraft.github.io/Documentation/"><i class="fa fa-cogs"></i> {text_api_docs}</a></li>
-            <li class="nav-item"><a class="nav-link text-light" href="https://github.com/TerraFirmaCraft/Field-Guide"><i class="fab fa-github"></i> {text_github}</a></li>
-            <li class="nav-item"><a class="nav-link text-light" href="https://discord.gg/PRuAKvY"><i class="fab fa-discord"></i> {text_discord}</a></li>
-            <li class="nav-item dropdown" id="version-dropdown">
-                <a class="nav-link dropdown-toggle text-light" id="version-dropdown-button" href="" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{text_version} {tfc_version}</a>
-                <div class="dropdown-menu" aria-labelledby="lang-dropdown-button" id="version-dropdown-menu">
-                </div>
-            </li>
-        </ul>
-    </div>
-</nav>
-<div class="container-fluid" style="margin-top:50px">
-    <div class="row">
-        <div class="col-md-2 py-1">
-            <div class="sticky-top" style="top: 70px">
-                <h4>{text_contents}</h4>
-                <ul class="list-unstyled">
-                    {contents}
-                </ul>
-            </div>
-        </div>
-        <div class="col-md-9 py-3">
-            <p><em>{location}</em></p>
-            {page_content}
-        </div>
-    </div>
-</div>
-</body>
+    <script src="{root}/static/metadata.js"></script>
+    <script src="{root}/static/tooltips.js"></script>
+    <script src="{root}/static/versions.js"></script>
+  </body>
 </html>

--- a/src/components/barrel_recipe.py
+++ b/src/components/barrel_recipe.py
@@ -20,7 +20,7 @@ def format_barrel_recipe_from_data(context: Context, buffer: List[str], data: An
     in_path = in_name = out_path = out_name = f_out_name = f_out_path = f_in_name = f_in_path = None
     in_count = out_count = 0
     input_fluid_div = input_item_div = output_fluid_div = output_item_div = duration = """"""
-    
+
     if 'input_item' in data:
         in_path, in_name = crafting_recipe.format_ingredient(context, data['input_item']['ingredient'])
         in_count = data['input_item']['count'] if 'count' in data['input_item'] else 1
@@ -59,7 +59,7 @@ def format_barrel_recipe_from_data(context: Context, buffer: List[str], data: An
 def make_icon(name, path, index: int, extra_bit: str = "") -> str:
     return f"""
         <div class="crafting-recipe-item two-recipe-pos-{str(index)}">
-            <span href="#" data-toggle="tooltip" title="{name}" class="crafting-recipe-item-tooltip"></span>
+            <span href="#" data-bs-toggle="tooltip" title="{name}" class="crafting-recipe-item-tooltip"></span>
             <img class="recipe-item" src="{path}" />
             {extra_bit}
         </div>

--- a/src/components/crafting_recipe.py
+++ b/src/components/crafting_recipe.py
@@ -46,7 +46,7 @@ def format_crafting_recipe_from_data(context: Context, buffer: List[str], identi
         return format_crafting_recipe_from_data(context, buffer, identifier, data)
     else:
         raise util.error('Unknown crafting recipe type: %s for recipe %s' % (recipe_type, identifier))
-    
+
     if recipe:
         recipe.grid = [
             format_ingredient(context, key) if key else None
@@ -58,22 +58,22 @@ def format_crafting_recipe_from_data(context: Context, buffer: List[str], identi
             <div class="crafting-recipe">
                 <img src="../../_images/crafting_%s.png" />
         """ % ('shapeless' if recipe.shapeless else 'shaped'))
-        
+
         for i, key in enumerate(recipe.grid):
             if key:
                 path, name = key
                 x, y = i % 3, i // 3
                 buffer.append("""
                 <div class="crafting-recipe-item crafting-recipe-pos-%d-%d">
-                    <span href="#" data-toggle="tooltip" title="%s" class="crafting-recipe-item-tooltip"></span>
+                    <span href="#" data-bs-toggle="tooltip" title="%s" class="crafting-recipe-item-tooltip"></span>
                     <img class="recipe-item" src="%s" />
                 </div>
                 """ % (x, y, name, path))
-        
+
         out_path, out_name, out_count = recipe.output
         buffer.append("""
                 <div class="crafting-recipe-item crafting-recipe-pos-out">
-                    <span href="#" data-toggle="tooltip" title="%s" class="crafting-recipe-item-tooltip"></span>
+                    <span href="#" data-bs-toggle="tooltip" title="%s" class="crafting-recipe-item-tooltip"></span>
                     %s
                     <img class="recipe-item" src="%s" />
                 </div>
@@ -83,7 +83,7 @@ def format_crafting_recipe_from_data(context: Context, buffer: List[str], identi
             out_name,
             format_count(out_count),
              out_path
-        ))        
+        ))
 
 
 def format_ingredient(context: Context, data: Any) -> Tuple[str, str]:

--- a/src/components/misc_recipe.py
+++ b/src/components/misc_recipe.py
@@ -77,12 +77,12 @@ def format_misc_recipe_from_data(context: Context, buffer: List[str], identifier
         <div class="crafting-recipe">
             <img src="../../_images/1to1.png" />
             <div class="crafting-recipe-item misc-recipe-pos-in">
-                <span href="#" data-toggle="tooltip" title="%s" class="crafting-recipe-item-tooltip"></span>
+                <span href="#" data-bs-toggle="tooltip" title="%s" class="crafting-recipe-item-tooltip"></span>
                 %s
                 <img class="recipe-item" src="%s" />
             </div>
             <div class="crafting-recipe-item misc-recipe-pos-out">
-                <span href="#" data-toggle="tooltip" title="%s" class="crafting-recipe-item-tooltip"></span>
+                <span href="#" data-bs-toggle="tooltip" title="%s" class="crafting-recipe-item-tooltip"></span>
                 %s
                 <img class="recipe-item" src="%s" />
             </div>

--- a/src/context.py
+++ b/src/context.py
@@ -69,7 +69,7 @@ class Context:
                 self.lang_keys.update(self.loader.load_lang(lang, domain))
             except InternalError as e:
                 LOG.warning('Translation : %s' % e)
-        
+
         self.with_local_lang('en_us')  # First load en_us
         self.with_local_lang(lang)  # Then load the current language
 
@@ -77,7 +77,7 @@ class Context:
         self.keybindings = {k[len('field_guide.'):]: self.translate(k) for k in I18n.KEYS}
 
         return self
-    
+
     def with_local_lang(self, lang: str):
         try:
             with open(util.path_join('./assets/lang/%s.json' % lang), 'r', encoding='utf-8') as f:
@@ -91,11 +91,11 @@ class Context:
         """ Returns a unique ID to be used in a id="" field. Successive calls will return a new ID. """
         self.last_uid[prefix] += 1
         return '%s%d' % (prefix, self.last_uid[prefix])
-    
+
     def add_entry(self, category_id: str, entry_id: str, entry: Entry):
         self.entries[entry_id] = entry
         self.categories[category_id].entries.append(entry_id)
-    
+
     def sort(self):
         """ Initializes sorted lists for all categories and entries. """
         self.sorted_categories = sorted([
@@ -105,11 +105,11 @@ class Context:
         for _, cat in self.sorted_categories:
             sorted_entry_names = sorted(cat.entries, key=lambda e: (self.entries[e].sort, e))
             cat.sorted_entries = [(e, self.entries[e]) for e in sorted_entry_names]
-    
+
     def format_text(self, buffer: List[str], data: Any, key: str = 'text'):
         if key in data:
             text_formatter.format_text(buffer, data[key], self.keybindings)
-    
+
     def format_title(self, buffer: List[str], data: Any, key: str = 'title'):
         if key in data:
             buffer.append('<h5>%s</h5>\n' % text_formatter.strip_vanilla_formatting(data[key]))
@@ -124,7 +124,7 @@ class Context:
             tooltip = title
         buffer.append("""
         <div class="item-header">
-            <span href="#" data-toggle="tooltip" title="%s">
+            <span href="#" data-bs-toggle="tooltip" title="%s">
                 <img src="%s" alt="%s" />
             </span>
             <%s>%s</%s>
@@ -135,14 +135,14 @@ class Context:
         buffer.append('<div style="text-align: center;">')
         self.format_text(buffer, data, key)
         buffer.append('</div>')
-    
+
     def format_with_tooltip(self, buffer: List[str], text: str, tooltip: str):
         buffer.append("""
         <div style="text-align: center;">
-            <p class="text-muted"><span href="#" data-toggle="tooltip" title="%s">%s</span></p>
+            <p class="text-muted"><span href="#" data-bs-toggle="tooltip" title="%s">%s</span></p>
         </div>
         """ % (tooltip, text))
-    
+
     def format_recipe(self, buffer: List[str], data: Any, key: str = 'recipe'):
         if key in data:
             self.format_with_tooltip(buffer, '%s: <code>%s</code>' % (
@@ -163,7 +163,7 @@ class Context:
             return IMAGE_CACHE[image]
 
         img = self.loader.load_explicit_texture(image)
-        
+
         width, height = img.size
         assert width == height and width % 256 == 0
         size = width * 200 // 256
@@ -179,7 +179,7 @@ class Context:
     def convert_icon(self, image: str) -> str:
         if image in IMAGE_CACHE:
             return IMAGE_CACHE[image]
-        
+
         img = self.loader.load_explicit_texture(image)
 
         width, height = img.size
@@ -190,4 +190,3 @@ class Context:
         ref = self.loader.save_image(self.next_id('image'), img)
         IMAGE_CACHE[image] = ref
         return ref
-


### PR DESCRIPTION
The white field guide theme was hurting my eyes at night, so I added a dark mode!

![Screenshot-2024-09-02-at-10-00-05-TerraFirmaCraft-Field-Guide](https://github.com/user-attachments/assets/ab8d817f-d5c3-417b-ac13-7b8103f924f6)

Users can switch between light, dark, and auto color themes using a new theme switcher menu in the top right of every page. Your theme choice is persisted using browser local storage.

You can see a demo here: https://raws.github.io/tfc-field-guide/en_us/

In order to take advantage of its new color theme utilities, I upgraded from Bootstrap 4.0 to 5.3, the latest stable release. That necessitated tweaking a bunch of HTML markup and CSS, and I did a round of general cleanup to adhere to current HTML and Bootstrap best practices. I made a couple of changes to the layout and typography to make things a tad more readable.

Other changes:

* Uncluttered the top nav bar by moving the Discord, GitHub and API docs links to a footer at the bottom of every page.
* Replaced Font Awesome icons with similar Bootstrap icons.
* Dynamically set the static asset path in GitHub Pages builds based on the GitHub repository name. This means that builds will work correctly even if someone changes the repo name from "Field-Guide" in a fork.
* **Known issue:** while most crafting grid background images can be dynamically inverted using CSS to fit dark mode, knapping recipes have a crafting frame baked into each recipe image, which can't be inverted without turning the stone texture mildly psychedelic. Luckily, it's still usable in dark mode as-is, just with lower contrast against the page background. Separating knapping recipes from their crafting frame would be a nice future enhancement.

More screenshots of the category and entry pages:

![Screenshot-2024-09-02-at-10-00-41-TerraFirmaCraft-Field-Guide](https://github.com/user-attachments/assets/0cecfb4d-87d5-42e8-8508-3dae3352901c)

![Screenshot-2024-09-02-at-10-01-11-TerraFirmaCraft-Field-Guide](https://github.com/user-attachments/assets/916059d8-7a95-40ad-bd0c-aa0a8158fb0f)