### PR TITLE
Precision Prospecting

### DIFF
--- a/src/components/misc_recipe.py
+++ b/src/components/misc_recipe.py
@@ -31,7 +31,12 @@ def format_misc_recipe(context: Context, buffer: List[str], identifier: str):
         else:
             util.error('Unrecognized loom recipe format: %s' % repr(data))
     elif recipe_type == 'tfc:anvil':
-        format_misc_recipe_from_data(context, buffer, identifier, data, ingredient=data['input'])
+        if 'input' in data:
+            format_misc_recipe_from_data(context, buffer, identifier, data, ingredient=data['input'])
+        elif 'ingredient' in data:
+            format_misc_recipe_from_data(context, buffer, identifier, data, ingredient=data['ingredient'])
+        else:
+            util.error('Unrecognized anvil recipe format: %s' % repr(data))
         tooltip = get_tier(context, data['tier'])
         buffer.append("""
         <div style="text-align: center;" class="minecraft-text minecraft-gray">

--- a/src/versions.py
+++ b/src/versions.py
@@ -65,6 +65,7 @@ FORGE_VERSION = '21.1.197'
 LANGUAGES = ('en_us', 'ja_jp', 'pt_br', 'ko_kr', 'uk_ua', 'zh_cn', 'zh_hk', 'zh_tw', 'ru_ru')
 
 ADDONS = (
+    Addon('Notenoughmail', 'precision-prospecting', 'v2.0', 'precisionprospecting', 'src/generated/resources')
 )
 
 OLD_VERSIONS = (

--- a/src/versions.py
+++ b/src/versions.py
@@ -6,15 +6,18 @@ class Addon(NamedTuple):
     repo: str  # Repository name
     version: str  # Addon version - this must be a tag, or commit hash (it will be passed to `git -b <version> clone`)
     mod_id: str  # Mod ID of the addon
-    resource_path: str  # Directory path within the repository of a `resources` folder (where `data` and `assets` might be loaded from)
+    resource_path: str | list[str]  # Directory path or paths within the repository of a `resources` folder (where `data` and `assets` might be loaded from). If a list, the first path must contain patchouli pages
 
     def book_dir(self, resource_pack: bool) -> str:
         return 'addons/%s-%s/%s/%s/tfc/patchouli_books/field_guide/' % (
             self.mod_id,
             self.version,
-            self.resource_path,
+            self.resource_paths()[0],
             ('assets' if resource_pack else 'data'),
         )
+    
+    def resource_paths(self) -> list[str]:
+        return self.resource_path if type(self.resource_path) == list else [self.resource_path]
 
 
 class OldVersion(NamedTuple):
@@ -65,7 +68,7 @@ FORGE_VERSION = '21.1.197'
 LANGUAGES = ('en_us', 'ja_jp', 'pt_br', 'ko_kr', 'uk_ua', 'zh_cn', 'zh_hk', 'zh_tw', 'ru_ru')
 
 ADDONS = (
-    Addon('Notenoughmail', 'precision-prospecting', 'v2.0', 'precisionprospecting', 'src/generated/resources')
+    Addon('Notenoughmail', 'precision-prospecting', 'v2.0', 'precisionprospecting', ['src/generated/resources', 'src/main/resources']),
 )
 
 OLD_VERSIONS = (
@@ -77,6 +80,13 @@ TFC_VERSION = '%s - %s' % (MC_VERSION, VERSION)
 
 IS_RESOURCE_PACK = MC_VERSION != '1.18.2'
 
+IS_PLURAL_REGISTRIES = MC_VERSION == '1.18.2' or MC_VERSION == '1.20.1'
+
+def registry(path: str) -> str:
+    if IS_PLURAL_REGISTRIES:
+        return path + 's'
+    else:
+        return path
 
 if __name__ == '__main__':
     print(VERSION)


### PR DESCRIPTION
Adds Precision Prospecting to the Field Guide for 1.21, also adds some enhancements that were easy

- Allow addons to specify multiple resource paths, useful when recipes are in a different source set than patchouli pages
- Allow anvil recipes to use either `input` or `ingredient` for the ingredient param, as that was changed in 1.21
- Only pluralize the `recipe`, `tags/item`. `tags/block`, and `tags/fluid` resource loader when in 1.20.1 or 1.18.2 land

Some further problems I noticed while poking about

- `loader.load_from_tfc` does not properly fallback to resources in the `generated` source set as it redefines the `path` variable
- `c` tags aren't loaded

I initially fixed the first issue, but that caused a *lot* of warnings related the second problem. Tired to fix that for a while to fix to no avail. When I have the time I'll look into it again if y'all haven't addressed it already